### PR TITLE
Correspondence when the end of the buffer is not null

### DIFF
--- a/Plugins/ObjectDeliverer/Source/ObjectDeliverer/Private/Utils/StringUtil.cpp
+++ b/Plugins/ObjectDeliverer/Source/ObjectDeliverer/Private/Utils/StringUtil.cpp
@@ -6,8 +6,8 @@ void UStringUtil::StringToBuffer(const FString& message, TArray<uint8>& DataBuff
 {
 	std::string _str = TCHAR_TO_UTF8(*message);
 
-	DataBuffer.SetNum(_str.size() + 2);
-	FMemory::Memset(DataBuffer.GetData(), 0, DataBuffer.Num());
+	DataBuffer.SetNum(_str.size() + 1);
+	DataBuffer[DataBuffer.Num() - 1] = 0x00;
 
 	FMemory::Memcpy(DataBuffer.GetData(), _str.c_str(), _str.size());
 
@@ -15,5 +15,15 @@ void UStringUtil::StringToBuffer(const FString& message, TArray<uint8>& DataBuff
 
 FString UStringUtil::BufferToString(const TArray<uint8>& DataBuffer)
 {
-	return UTF8_TO_TCHAR(DataBuffer.GetData());
+	if (DataBuffer[DataBuffer.Num() - 1] == 0x00)
+	{
+		return UTF8_TO_TCHAR(DataBuffer.GetData());
+	}
+
+	TArray<uint8> tempBuffer;
+	tempBuffer.SetNum(DataBuffer.Num() + 1);
+	FMemory::Memcpy(tempBuffer.GetData(), DataBuffer.GetData(), DataBuffer.Num());
+	tempBuffer[tempBuffer.Num() - 1] = 0x00;
+
+	return UTF8_TO_TCHAR(tempBuffer.GetData());
 }


### PR DESCRIPTION
In "UStringUtil :: BufferToString", fixed the phenomenon that dust is attached to the end of the string if 0x00 is not at the end of the buffer