### PR TITLE
UObject dynamic class serialization WIP

### DIFF
--- a/Plugins/ObjectDeliverer/Source/ObjectDeliverer/Private/DeliveryBox/ObjectDeliveryBoxUsingJson.cpp
+++ b/Plugins/ObjectDeliverer/Source/ObjectDeliverer/Private/DeliveryBox/ObjectDeliveryBoxUsingJson.cpp
@@ -47,6 +47,15 @@ void UObjectDeliveryBoxUsingJson::NotifyReceiveBuffer(const UObjectDelivererProt
 
 	UObjectJsonSerializer::JsonObjectToUObject(JsonObject, createdObj);
 
+  if (!createdObj)
+    return;
+
+  // With dynamic object class serialization it is not necessary to specify TargetClass */
+  // TODO: think of throwing away TargetClass
+  //       this will let user set more flexible object class checks
+  if (!createdObj->GetClass()->IsChildOf(TargetClass))
+    return
+
 	Received.Broadcast(createdObj, FromObject);
 }
 

--- a/Plugins/ObjectDeliverer/Source/ObjectDeliverer/Private/Utils/ObjectJsonSerializer.h
+++ b/Plugins/ObjectDeliverer/Source/ObjectDeliverer/Private/Utils/ObjectJsonSerializer.h
@@ -12,8 +12,24 @@ class OBJECTDELIVERER_API UObjectJsonSerializer : public UObject
 
 public:
 
-	static TSharedPtr<FJsonObject> CreateJsonObject(const UObject* Obj);
-	static bool JsonObjectToUObject(const TSharedPtr<FJsonObject>& JsonObject, UObject* OutObject);
+  /* * Serializes UObject as FJsonObject
+   *
+   * @param Obj			      The object to serialize
+   * @param CheckFlags		Only convert properties that match at least one of these flags. If 0 check all properties.
+   * @param SkipFlags			Skip properties that match any of these flags
+   *
+   * @return					    The constructed FJsonObject shared ptr from the Obj
+   */
+	static TSharedPtr<FJsonObject> CreateJsonObject(const UObject* Obj, int64 CheckFlags=0, int64 SkipFlags=0);
+
+  /* * Create UObject from serialized FJsonObject
+  *
+  * @param JsonObject		  The Json with serailized UObject information
+  * @param OutObject		  Created object
+  *
+  * @return					      If created successfully
+  */
+	static bool JsonObjectToUObject(const TSharedPtr<FJsonObject>& JsonObject, UObject*& OutObject);
 
 private:
 	static TSharedPtr<FJsonValue> ObjectJsonCallback(UProperty* Property, const void* Value);
@@ -32,5 +48,6 @@ private:
 	static bool JsonValueToUStructProperty(const TSharedPtr<FJsonValue>& JsonValue, UStructProperty* StructProperty, void* OutValue);
 	static bool JsonValueToUObjectProperty(const TSharedPtr<FJsonValue>& JsonValue, UObjectProperty* ObjectProperty, void* OutValue);
 
-
+  static const FString objectClassNameKey;
+  static const FString objectPropertiesKey;
 };

--- a/Plugins/ObjectDeliverer/Source/ObjectDeliverer/Private/Utils/ObjectUtil.cpp
+++ b/Plugins/ObjectDeliverer/Source/ObjectDeliverer/Private/Utils/ObjectUtil.cpp
@@ -1,5 +1,6 @@
 // Copyright 2019 ayumax. All Rights Reserved.
 #include "ObjectUtil.h"
+#include "Package.h"
 
 EUPropertyType UObjectUtil::GetUPropertyType(UProperty* Property)
 {
@@ -64,4 +65,10 @@ EUPropertyType UObjectUtil::GetUPropertyType(UProperty* Property)
 	}
 
 	return EUPropertyType::None;
+}
+
+bool UObjectUtil::FindClass(const FString& ClassName, UClass*& Class)
+{
+  Class = FindObject<UClass>(ANY_PACKAGE, *ClassName);
+  return Class != nullptr;
 }

--- a/Plugins/ObjectDeliverer/Source/ObjectDeliverer/Private/Utils/ObjectUtil.h
+++ b/Plugins/ObjectDeliverer/Source/ObjectDeliverer/Private/Utils/ObjectUtil.h
@@ -34,5 +34,6 @@ public:
 
 	static EUPropertyType GetUPropertyType(UProperty* Property);
 
+  static bool FindClass(const FString& ClassName, UClass*& Class);
 
 };


### PR DESCRIPTION
Hello, 
I was thinking of how to improve my saving system with built-in serialization and after a few days of looking through UE4 serialization and archive code found out that part of your plugin does a big part of the job needed. Although, I see some improvements to be made and I want to contribute code that I came up with.

[ NOT TESTED ]
[ BUILT WITH UE4.23.1 ]

Feature to support UObjects with dynamic classes added to Utils/ObjectJsonSerializer

Before:
Top level UObject class was set with TargetClass
Nested UObject classes were set with higher level UObject/UStruct UObjectProperty->PropertyClass
Issue:
If serialized UObject inherited from UObjectProperty->PropertyClass and all subclass-specific information will be lost on de-serialization. This means UObjectProperty->PropertyClass UObject will be created, serialized subclass properties will be ignored.

Now:
UObject class name is serialized.
UObject of serialized class should be created.
No serialized properties should be ignored.

Please, tell if this feature is out-of-design and test it.