### PR TITLE
Uses default FString constructor

### DIFF
--- a/Plugins/ObjectDeliverer/Source/ObjectDeliverer/Public/DeliveryDataType.h
+++ b/Plugins/ObjectDeliverer/Source/ObjectDeliverer/Public/DeliveryDataType.h
@@ -19,6 +19,6 @@ struct FDeliveryDataType
 
 	static FDeliveryDataType Default()
 	{
-		return FDeliveryDataType(EMainType::Binary, _TEXT(""));
+		return FDeliveryDataType(EMainType::Binary, FString());
 	}
 };


### PR DESCRIPTION
Replaces `_TEXT("")` with the default `FString()` constructor in `FDeliveryDataType::Default()`.

This avoids potential issues with character encoding and ensures consistency with Unreal Engine's string handling practices.

## Pull Request Description

### Overview
<!-- Provide a clear and concise description of what this PR implements or changes -->

### Motivation
<!-- Explain why this PR is necessary and what problem it solves -->

### Changes Made
<!-- List the key changes made in this PR -->

### Testing Status
- [ ] All tests are passing
- [ ] Some tests are failing (explain below)
- [ ] No tests were added or modified

### Explanation for Failing Tests (if applicable)
<!-- If any tests are failing, please explain why and whether this is acceptable -->

### Additional Information
<!-- Any other information that might be helpful for reviewers -->

### Screenshots/Videos (if applicable)
<!-- Add any visual aids that help demonstrate the changes -->

### Checklist
- [ ] I have tested these changes locally
- [ ] I have updated documentation as needed
- [ ] This PR targets the `master` branch
- [ ] I have added/updated tests to cover my changes (if applicable)

### Related Issues
<!-- Reference any related issues with "Fixes #123" or "Related to #123" -->
